### PR TITLE
ci: add GitHub Actions workflow 'Pipeline'

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,0 +1,32 @@
+name: Pipeline
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
+
+jobs:
+
+
+  LaTeX:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: '🧰 Checkout'
+      uses: actions/checkout@v3
+
+    - name: '📓 Build PDF (pdflatex) on container btdi/latex'
+      run: |
+        docker run --rm -iv $(pwd):/wrk -w /wrk btdi/latex bash <<EOF
+        #!/usr/bin/env bash
+        cd latex
+        pdflatex main.tex
+        pdflatex main.tex
+        EOF
+
+    - name: '📤 Upload artifact: PDF'
+      uses: actions/upload-artifact@v3
+      with:
+        path: latex/main.pdf

--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -30,3 +30,22 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: latex/main.pdf
+
+    - name: '🚀 Publish to gh-pages'
+      if: github.event_name != 'pull_request'
+      run: |
+        mkdir dist
+        mv latex/main.pdf dist
+        cat > dist/index.html <<EOF
+        <a href="main.pdf">PDF</a>
+        EOF
+
+        cd dist
+        touch .nojekyll
+        git init
+        cp ../.git/config ./.git/config
+        git add .
+        git config --local user.email "push@gha"
+        git config --local user.name "GHA"
+        git commit -a -m "update ${{ github.sha }}"
+        git push -u origin +HEAD:gh-pages


### PR DESCRIPTION
GitHub Actions eta GitHub Pages erabiltzeko adibide xumea da hau. Kodea klonatu eta `btdi/latex` kontenedorea erabilita exekutatzen du pdflatex. Emaitza, `main.pdf`, artifact gisa gordetzen da. Hortaz gain, "web gune" bat sortzen da (`<a href="main.pdf">PDF</a>`) eta PDF-arekin batera `gh-pages` adarrera igo. Horrela:

- Erabiltzaileek edukia irakur dezakete lokalean LaTeX instalatu barik.
- Laguntzaileek ere, egin nahi dituzten aldaketak (feature-branch edo PRak) frogatu ditzakete.

Ikus https://umarcor.github.io/html5liburua/ eta https://umarcor.github.io/html5liburua/main.pdf. PR hau onartzean, `juananpe.github.io/html5liburua` izango da errepositorio honi dagokion URLa.

Proposatutako web gunea ez da web gunea bez. Esteka bat baino ez da. https://ikasten.io/html5/ dagoenez, beharbada bertara esteka gehitu nahiko duzu, o bestelako ariketak/adibideak. Horregatik adibide sinpleena egin dut hemen.

